### PR TITLE
Fix typo in customize script

### DIFF
--- a/python/customize.py
+++ b/python/customize.py
@@ -101,7 +101,7 @@ def compare_raw_reco_sev9(process):
 
 
 def compare_reemul_reco_sev9(process):
-    return compare_tp_reco(process, 'compareRawRecoSeverity9', 'simHcalTriggerPrimitiveDigis', 'hcalDigis', 9)
+    return compare_tp_reco(process, 'compareReemulRecoSeverity9', 'simHcalTriggerPrimitiveDigis', 'hcalDigis', 9)
 
 
 def compare_raw_reco_sev9999(process):


### PR DESCRIPTION
The output directory for the comparisons between RecHits and re-emulated TP currently has the same name as that for the RecHit to RAW TP comparisons. This PR fixes the typo.